### PR TITLE
Remove debug mode output from efg_internal_config.html5 template

### DIFF
--- a/templates/internal/efg_internal_config.html5
+++ b/templates/internal/efg_internal_config.html5
@@ -1,7 +1,8 @@
 <?php
   // Disable the debug mode (see #2)
   \Config::set('debugMode', false);
-  echo '<?php'; ?>
+  echo '<?php';
+?>
 
 
 /**

--- a/templates/internal/efg_internal_config.html5
+++ b/templates/internal/efg_internal_config.html5
@@ -1,4 +1,7 @@
-<?php echo '<?php'; ?>
+<?php
+  // Disable the debug mode (see #2)
+  \Config::set('debugMode', false);
+  echo '<?php'; ?>
 
 
 /**


### PR DESCRIPTION
As mentioned in #2 I added a line to temporarily disable the debug mode so the config file will not be broken if the debug mode is enabled.